### PR TITLE
Fix "DataCloneError: DOM Exception 25: An object could not be cloned" in Safari 7

### DIFF
--- a/forge.safariextension/assets_forge/api-safari.js
+++ b/forge.safariextension/assets_forge/api-safari.js
@@ -34,7 +34,7 @@ safari.self.addEventListener("message", internal.dispatchMessage, false);
 
 internal.priv.send = function (data) {
 	if (safari.self.tab) {
-		safari.self.tab.dispatchMessage(('forge-bridge'+forge.config.uuid), data);
+		safari.self.tab.dispatchMessage(('forge-bridge'+forge.config.uuid), JSON.parse(JSON.stringify(data)));
 	} else {
 		// Being called within a popover, call the dispatch function directly
 		safari.extension.globalPage.contentWindow.forge._dispatchMessage({


### PR DESCRIPTION
A new version of Safari will arrive soon in OS X 10.9 Mavericks. 
When I try to use extension in Safari Version 7.0 (9537.71), it gives an error:

<pre>DataCloneError: DOM Exception 25: An object could not be cloned</pre>

So this patch will fix the issue in Safari 7, tested on Safari 6 as well
