### PR TITLE
update genshi to 0.6

### DIFF
--- a/generate/requirements.txt
+++ b/generate/requirements.txt
@@ -1,4 +1,4 @@
-Genshi==0.5
+Genshi==0.6
 Jinja2==2.6
 Pygments==1.4
 Sphinx==1.0.8


### PR DESCRIPTION
0.5 isnt available via default pip anymore, and genshi 0.7 has an issue with windows line endings and backslashes:
http://genshi.edgewall.org/ticket/569
