### PR TITLE
Move extension button to Tools Bar in IE9+

### DIFF
--- a/ie/source/WindowsMessage.cpp
+++ b/ie/source/WindowsMessage.cpp
@@ -10,34 +10,121 @@
  */
 HWND WindowsMessage::GetToolbar(HWND ieframe, HWND *out_toolbar, HWND *out_target)
 {
-    *out_toolbar = NULL;
-    *out_target  = NULL;
+    if (out_toolbar) *out_toolbar = NULL;
+    if (out_target)  *out_target = NULL;
 
-    HWND commandbar = ::FindWindowEx(ieframe, NULL, _T("CommandBarClass"),  NULL);
-	if (!commandbar) {
-        logger->error(L"WindowsMessage::GetToolbar failed to get CommandBarClass");
-        return NULL;
+    // List of window classes to traverse from IEFrame window to toolbar window where we place the icon:
+    // IE7 Command bar right of tabs
+    static const wchar_t* ie7_cmd_bar[] = { L"CommandBarClass", L"ReBarWindow32", L"ToolbarWindow32" };
+    // IE8+ Command bar right of tabs. Hidden by default on IE9+
+    static const wchar_t* ie8_cmd_bar[] = { L"CommandBarClass", L"ReBarWindow32", L"CommandToolbarBand", L"ToolbarWindow32" };
+    // IE9+ Favorites and Tools bar right of address bar
+    static const wchar_t* ie9_tools_bar[] = { L"WorkerW", L"ReBarWindow32", L"ControlBandClass", L"ToolbarWindow32" };
+
+    int ie_major = 0, ie_minor = 0;
+    if (FAILED(GET_MSIE_VERSION(&ie_major, &ie_minor))) {
+        logger->error(L"WindowsMessage::GetToolbar failed to determine IE version, assuming IE 9");
+        ie_major = 9;
     }
-    HWND rebar = ::FindWindowEx(commandbar, NULL, _T("ReBarWindow32"), NULL);
-	if (!rebar) {
-        logger->error(L"WindowsMessage::GetToolbar failed to get ReBarWindow32");
-        return NULL;
+
+    wstringvector class_list;
+    if (ie_major >= 9) {
+        class_list = wstringvector(ie9_tools_bar, staticarray_end(ie9_tools_bar));
     }
-    HWND commandtoolbar = ::FindWindowEx(rebar, NULL, _T("CommandToolbarBand"), NULL); // Only >= IE8 ?
-	if (!commandtoolbar) {
-        logger->error(L"WindowsMessage::GetToolbar failed to get CommandToolbarBand");
-        return NULL;
+    else if (ie_major == 8) {
+        class_list = wstringvector(ie8_cmd_bar, staticarray_end(ie8_cmd_bar));
     }
-    HWND toolbar = ::FindWindowEx(commandtoolbar, NULL, _T("ToolbarWindow32"), NULL);
-    if (!toolbar) {
-        logger->error(L"WindowsMessage::GetToolbar failed to get ToolbarWindow32");
-        return NULL;
+    else {
+        class_list = wstringvector(ie7_cmd_bar, staticarray_end(ie7_cmd_bar));
     }
+
+    logger->debug(L"WindowsMessage::GetToolbar class list"
+                  L" -> " + boost::algorithm::join(class_list, L", "));
+
+    HWND window = ieframe;
+    HWND parent = ieframe;
+    wstringvector::const_iterator window_class = class_list.begin();
+    for (; window_class != class_list.end(); window_class++) {
+        parent = window;
+        window = ::FindWindowEx(parent, NULL, (*window_class).c_str(), NULL);
+        if (!window) {
+            logger->error(L"WindowsMessage::GetToolbar failed to get " + *window_class);
+            return NULL;
+        }
+    }
+
+    if (out_toolbar) *out_toolbar = window;
+    if (out_target)  *out_target  = parent;
     
-    if (out_toolbar) *out_toolbar = toolbar;
-    if (out_target)  *out_target  = commandtoolbar;
-    
-    return toolbar;
+    return window;
+}
+
+/**
+* Helper: AddToolbarIcon
+*
+* Adds or replaces an icon on all image lists used by the toolbar.
+* If index is -1 the icon will be added to the end of the lists and its new
+* index returned.
+* If index is specified and an icon already exists at that index the
+* previous icon will be replaced.
+*/
+bool WindowsMessage::AddToolbarIcon(HWND toolbar, HICON icon, int *index)
+{
+    if (!index) {
+        logger->error(L"WindowsMessage::AddToolbarIcon invalid index argument");
+        return false;
+    }
+
+    // Deal with main image list first. If this fails we error.
+    HIMAGELIST main_list = reinterpret_cast<HIMAGELIST>(::SendMessage(toolbar, TB_GETIMAGELIST, 0, 0));
+    if (!main_list) {
+        logger->error(L"WindowsMessage::AddToolbarIcon failed to get main image list"
+                      L" -> " + boost::lexical_cast<wstring>(toolbar));
+        return false;
+    }
+
+    int main_index = ::ImageList_ReplaceIcon(main_list, *index, icon);
+    if (main_index == -1) {
+        logger->error(L"WindowsMessage::AddToolbarIcon failed to add/replace main icon"
+                      L" -> " + boost::lexical_cast<wstring>(toolbar) +
+                      L" -> " + boost::lexical_cast<wstring>(index));
+        return false;
+    }
+
+    // Add the icon to all secondary image lists the toolbar has
+    static const DWORD secondary_lists[] = { TB_GETHOTIMAGELIST,
+                                             TB_GETPRESSEDIMAGELIST,
+                                             TB_GETDISABLEDIMAGELIST };
+
+    for (int i = 0; i < sizeof(secondary_lists) / sizeof(secondary_lists[0]); i++) {
+        HIMAGELIST secondary_list = reinterpret_cast<HIMAGELIST>(::SendMessage(toolbar, secondary_lists[i], 0, 0));
+        if (!secondary_list) {
+            // Failure to get the a secondary image list is not fatal. In fact it is
+            // excpected for the IE Command Bar and we only need it when using the IE9+
+            // Tools Bar. See WindowsMessage::GetToolbar() for reference.
+            /*
+            logger->debug(L"button_addCommand::exec failed to get secondary image list"
+                          L" -> " + boost::lexical_cast<wstring>(i));
+            */
+            continue;
+        }
+
+        int secondary_index = ::ImageList_ReplaceIcon(secondary_list, *index, icon);
+        if (secondary_index == -1 || secondary_index != main_index) {
+            // The image lists have gone out of sync somehow and the user will might
+            // the wrong icon in some cases. Not much we can do about it.
+            logger->error(L"WindowsMessage::AddToolbarIcon failed to add/replace secondary icon"
+                          L" -> " + boost::lexical_cast<wstring>(i) +
+                          L" -> " + boost::lexical_cast<wstring>(index) +
+                          L" -> " + boost::lexical_cast<wstring>(main_index) +
+                          L" -> " + boost::lexical_cast<wstring>(secondary_index));
+            // Continue to hopefully get the other lists right
+            continue;
+        }
+    }
+
+    *index = main_index;
+    return true;
 }
 
 

--- a/ie/source/WindowsMessage.h
+++ b/ie/source/WindowsMessage.h
@@ -4,7 +4,8 @@
 
 namespace WindowsMessage {
     // helpers
-    HWND   GetToolbar(HWND ieframe, HWND *toolbar = NULL, HWND *target = NULL);
+    HWND GetToolbar(HWND ieframe, HWND *toolbar = NULL, HWND *target = NULL);
+    bool AddToolbarIcon(HWND toolbar, HICON icon, int *index);
 
     // messages
     int  tb_buttoncount(HWND hwnd);


### PR DESCRIPTION
OpenForge adds the extension button to the IE Command Bar at the moment. This bar is by default not visible from IE9 onwards and most users would never enable it.

This patch moves the button to the Favorites and Tools Bar in IE9+ which is always visible and more in line with how the extension will appear in Firefox and Chrome:

![openforge_ie9_button](https://cloud.githubusercontent.com/assets/2941874/2945876/cf15ca56-d9e5-11e3-90df-89e4233d2612.png)

![openforge_ie9_icon_new](https://cloud.githubusercontent.com/assets/2941874/2945992/fd83aa92-d9e6-11e3-92be-51f904360fbd.png)
