### PR TITLE
make background page use latest available IE version

### DIFF
--- a/ie/forge.html
+++ b/ie/forge.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <style>
             html {
               font-family : Helvetica, Verdana, Arial, sans-serif;
@@ -81,10 +82,10 @@
                 };
             </script>
     </head>
-    
+
     <body>
         <div id="content">
-            
+
             <div id="wrapper_top">
                 <div class="left">
                     <h2>Scripts</h2>
@@ -116,8 +117,8 @@
                 <h2>Log</h2>
                 <div id="forgeconsole"></div>
             </div> <!-- wrapper_bottom -->
-            
+
         </div> <!-- #content -->
     </body>
-    
+
 </html>


### PR DESCRIPTION
The background window in IE comes up in IE7 mode; this is apparently the
default for embedded internet explorer controls. This change makes the
page load up using the latest available IE, though perhaps not for pages
that would be considered 'intranet' pages.

The following stack overflow queries seem relevant, found via searching
for related keywords on using IWebBrowser2:
http://stackoverflow.com/questions/6914664/iwebbrowser2-object-uses-ie7-version-instead-of-the-ie-version-installed-on-the
http://stackoverflow.com/questions/4097593/how-to-put-the-webbrowser-control-into-ie9-into-standards
