### PR TITLE
Insert scripts after meta tags

### DIFF
--- a/generate/generate/customer_phases.py
+++ b/generate/generate/customer_phases.py
@@ -60,25 +60,21 @@ def include_platform_in_html(debug=False):
 		locations = locations_debug
 
 	return [
-		{'when': {'platform_is': 'firefox'}, 'do': {'find_and_replace_in_dir': {
+		{'when': {'platform_is': 'firefox'}, 'do': {'insert_head_tag': {
 			"root_dir": locations["firefox"],
-			"find": "<head>",
-			"replace": "<head><script src='%{back_to_parent}%forge/app_config.js'></script><script src='%{back_to_parent}%forge/all.js'></script>"
+			"tag": "<script src='%{back_to_parent}%forge/app_config.js'></script><script src='%{back_to_parent}%forge/all.js'></script>"
 		}}},
-		{'when': {'platform_is': 'chrome'}, 'do': {'find_and_replace_in_dir': {
+		{'when': {'platform_is': 'chrome'}, 'do': {'insert_head_tag': {
 			"root_dir": locations["chrome"],
-			"find": "<head>",
-			"replace": "<head><script src='/forge/app_config.js'></script><script src='/forge/all.js'></script>"
+			"tag": "<script src='/forge/app_config.js'></script><script src='/forge/all.js'></script>"
 		}}},
-		{'when': {'platform_is': 'safari'}, 'do': {'find_and_replace_in_dir': {
+		{'when': {'platform_is': 'safari'}, 'do': {'insert_head_tag': {
 			"root_dir": locations["safari"],
-			"find": "<head>",
-			"replace": "<head><script src='%{back_to_parent}%forge/app_config.js'></script><script src='%{back_to_parent}%forge/all.js'></script>"
+			"tag": "<script src='%{back_to_parent}%forge/app_config.js'></script><script src='%{back_to_parent}%forge/all.js'></script>"
 		}}},
-		{'when': {'platform_is': 'ie'}, 'do': {'find_and_replace_in_dir': {
+		{'when': {'platform_is': 'ie'}, 'do': {'insert_head_tag': {
 			"root_dir": locations["ie"],
-			"find": "<head>",
-			"replace": "<head><script src='%{back_to_parent}%forge/app_config.js'></script><script src='%{back_to_parent}%forge/all.js'></script>"
+			"tag": "<script src='%{back_to_parent}%forge/app_config.js'></script><script src='%{back_to_parent}%forge/all.js'></script>"
 		}}},
 	]
 

--- a/generate/generate/customer_tasks.py
+++ b/generate/generate/customer_tasks.py
@@ -334,6 +334,23 @@ def write_config(build, filename, content):
 		fileobj.write(content)
 
 @task
+def insert_head_tag(build, root_dir, tag, file_suffixes=("html",), template=False, **kw):
+	'''For all files ending with one of the suffixes, under the root_dir, insert ``tag`` as
+	early as possible after the <head> tag but after any <meta> tags.
+	'''
+	if template:
+		tag = utils.render_string(build.config, tag)
+
+	build.log.debug("inserting {tag} into <head> of {files}".format(
+		tag=tag, files="{0}/**/*.{1}".format(root_dir, file_suffixes)
+	))
+
+	find = r'<head>((\s*<meta[^>]+>)*)'
+	replace = r'<head>\1\n' + tag
+
+	find_and_replace_in_dir(build, root_dir, find, replace, file_suffixes)
+
+@task
 def find_and_replace_in_dir(build, root_dir, find, replace, file_suffixes=("html",), template=False, **kw):
 	'For all files ending with one of the suffixes, under the root_dir, replace ``find`` with ``replace``'
 	if template:
@@ -352,7 +369,7 @@ def find_and_replace_in_dir(build, root_dir, find, replace, file_suffixes=("html
 				if file_.rpartition('.')[2] in file_suffixes:
 					find_with_fixed_path = find.replace("%{back_to_parent}%", "../" * (depth+1))
 					replace_with_fixed_path = replace.replace("%{back_to_parent}%", "../" * (depth+1))
-					_replace_in_file(build, path.join(root, file_), find_with_fixed_path, replace_with_fixed_path)
+					regex_replace_in_file(build, path.join(root, file_), find_with_fixed_path, replace_with_fixed_path)
 
 def _replace_in_file(build, filename, find, replace):
 	build.log.debug(u"replacing {find} with {replace} in {filename}".format(**locals()))


### PR DESCRIPTION
At the moment the build system inserts OpenForge scripts tags directly after `<head>` in all html files the extension uses. This prevents extensions from using the latest IE version in the popup window by inserting a `<meta http-equiv="X-UA-Compatible" content="IE=edge" />` tag. IE only recognises this tag properly if it comes before anything else in the head.

This patch makes sure the OpenForge scripts are only inserted after any meta tags in the page head.

See also #30 for a related issue involving the background page.
