### PR TITLE
Temporarily fix for firefox 30+ background script

### DIFF
--- a/firefox/template-app/package.json
+++ b/firefox/template-app/package.json
@@ -5,5 +5,8 @@
 	"id": "PACKAGE_NAME_HERE",
 	"description": "DESCRIPTION_HERE",
 	"author": "AUTHOR_HERE",
+	"permissions": {
+		"unsafe-content-script": true
+	},
 	"homepage": ${json.dumps(value_of("homepage", ""))}
 }


### PR DESCRIPTION
This fixes https://github.com/trigger-corp/browser-extensions/issues/36, until a long term solution is implemented (https://blog.mozilla.org/addons/2014/04/10/changes-to-unsafewindow-for-the-add-on-sdk/)
