### PR TITLE
Bump "biplist" version to 0.6

### DIFF
--- a/generate/requirements.txt
+++ b/generate/requirements.txt
@@ -3,7 +3,7 @@ Jinja2==2.6
 Pygments==1.4
 Sphinx==1.0.8
 argparse==1.1
-biplist==0.5
+biplist==0.6
 chardet==1.0.1
 coverage==3.5.1
 docutils==0.8.1


### PR DESCRIPTION
Bumping `biplist` to version `0.6` so the setup process works on Mac OSX Sierra 10.12.6 (The old `0.5` version was causing `SSL` errors during setup)